### PR TITLE
/seed, /dropoff and /dropoffs  working

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -7,22 +7,30 @@ const csv = require('csvtojson');
 const fetch = require("node-fetch");
 
 const app = express();
+app.use(express.json());
 const router = express.Router();
 const port = 8080;
 const Dropoffs = require("./models/Dropoffs.js");
 const db = require('./models/index');
+const loadDropoffs = require('./seeders/loadDropoffs');
 
 app.get("/status", (req, res) => {
   res.send(`ok at ${new Date()}`)
 })
 
+app.get("/seed", (req, res, next) => {
+  db.sequelize.sync({ force: true }) // reset db
+    .then(loadDropoffs)
+    .then(() => res.json({ message: "database seeded" }))
+    .catch(next)
+})
 
 app.get("/dropoff/:state.:state_county", function(req, res) {
   let state = req.params["state"];
   let state_county = req.params["state_county"];
   db.Dropoffs.findAll(
     {where: {state_short_code: state,
-    county: state_county}}).then( function(dropoffs) 
+    county: state_county}}).then( function(dropoffs)
     {
         if (!dropoffs) {
           res.send([])
@@ -32,6 +40,29 @@ app.get("/dropoff/:state.:state_county", function(req, res) {
       res.send({"Error": "Error occurred"})
     });
 });
+
+app.post("/dropoff", (req, res, next) => {
+  db.Dropoffs.create(req.body)
+    .then(data => res.json(data))
+    .catch(next)
+})
+
+app.post("/dropoffs", (req, res, next) => {
+  db.Dropoffs.bulkCreate(req.body, { validate: true })
+    .then(data => res.json(data))
+    .catch(next)
+})
+
+// handle errors
+app.use((err, req, res, next) => {
+  if (
+    err instanceof db.Sequelize.ValidationError ||
+    err instanceof db.Sequelize.AggregateError
+  )
+    res.status(400).send(err)
+  else
+    res.status(500).send(err.message)
+})
 
 app.listen(port, function () {
   console.log("App listening on port 8080!");

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - NODE_ENV=development
     depends_on:
       - db
-    command: npx nodemon -w /ballotnav/app.js -w /ballotnav/models -L app.js
+    command: npx nodemon -w /ballotnav/app.js -w /ballotnav/models -w /ballotnav/seeders -L app.js
 
   db:
     image: postgres:11

--- a/backend/models/Dropoffs.js
+++ b/backend/models/Dropoffs.js
@@ -18,7 +18,7 @@ const Dropoffs = function (sequelize, DataTypes) {
     },
     position: {
         type: DataTypes.STRING
-    }, 
+    },
     contact_name: {
         type: DataTypes.STRING
     },
@@ -27,7 +27,7 @@ const Dropoffs = function (sequelize, DataTypes) {
     },
     address_2: {
         type: DataTypes.STRING
-    }, 
+    },
     email: {
         type: DataTypes.STRING
     },
@@ -44,12 +44,12 @@ const Dropoffs = function (sequelize, DataTypes) {
         type: DataTypes.STRING
     },
     latitude: {
-        type: DataTypes.INTEGER
-    }, 
+        type: DataTypes.FLOAT
+    },
     longitude: {
-        type: DataTypes.INTEGER
-    } 
-  }); 
+        type: DataTypes.FLOAT
+    }
+  });
 }
 
 module.exports = Dropoffs;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -656,6 +656,11 @@
         }
       }
     },
+    "faker": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
+      "integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
+    },
     "fill-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "csvtojson": "^2.0.10",
     "express": "^4.17.1",
+    "faker": "^5.1.0",
     "node-fetch": "^2.6.1",
     "pg": "^8.3.3",
     "pg-hstore": "^2.3.3",

--- a/backend/seeders/loadDropoffs.js
+++ b/backend/seeders/loadDropoffs.js
@@ -1,0 +1,31 @@
+const faker = require('faker')
+const db = require('../models')
+
+faker.seed(123)
+const NUM_RECORDS = 500
+
+function randomDropoff() {
+  return {
+    state_name: faker.address.state(),
+    state_short_code: faker.address.stateAbbr(),
+    county: faker.address.county(),
+    position: faker.name.jobTitle(),
+    contact_name: faker.name.firstName() + ' ' + faker.name.lastName(),
+    address_1: faker.address.streetAddress(),
+    address_2: faker.address.secondaryAddress(),
+    email: faker.internet.email(),
+    fax: faker.phone.phoneNumberFormat(),
+    phone: faker.phone.phoneNumberFormat(),
+    county_website: faker.internet.url(),
+    source_url: faker.internet.url(),
+    latitude: faker.address.latitude(),
+    longitude: faker.address.longitude(),
+  }
+}
+
+function loadDropoffs() {
+  const dropoffs = Array.from({ length: NUM_RECORDS }).map(randomDropoff)
+  return db.Dropoffs.bulkCreate(dropoffs)
+}
+
+module.exports = loadDropoffs


### PR DESCRIPTION
This adds three endpoints:

`GET /seed`

Creates the Dropoffs table and adds 500 rows of dummy data. The data is from faker.js. Figure we can replace it with a csv file when we have some real data.

`POST /dropoff` 

Adds a single dropoff to the table. Validates the input and returns the entry that was created.

`POST /dropoffs` 

Adds an array of dropoffs to the table. Validates the input and returns an array of new entries.
