### PR TITLE
ci: fix tagging on backend build

### DIFF
--- a/.github/workflows/backend-build.yaml
+++ b/.github/workflows/backend-build.yaml
@@ -14,8 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     name: build & push image
     steps:
+
       - name: Checkout repo
         uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Prepare docker tag
+        id: prepare
+        run: |
+          SHA=${{ github.sha }}
+          echo ::set-output name=sha::${SHA:0:8}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -29,6 +42,8 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
-          user: ballotnav/ballotnav:latest
+          push: true
+          tags: ballotnav/ballotnav:${{ steps.prepare.outputs.sha }}
+
       - name: built image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION

adds more steps to get the git SHA and set as the tag
on the image.

