### PR TITLE
ci: use npm ci in docker install to build from lockfile;

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,10 @@
 FROM node:12
 
-COPY package*.json ./ballotnav/
+COPY package.json ./ballotnav/
+COPY package-lock.json ./ballotnav/
 
 WORKDIR /ballotnav
-RUN npm install
+RUN npm ci
 
 COPY . .
 


### PR DESCRIPTION

this is good for CI and deploy as it will give us a deterministic
build.

