### PR TITLE
started wip crud

### DIFF
--- a/backend/controllers/admin.js
+++ b/backend/controllers/admin.js
@@ -10,7 +10,7 @@ exports.listJurisdictions = async (req, res, next) => {
 // TODO: modify so that it returns the user's assigned jurisdictions
 exports.listMyJurisdictions = async (req, res, next) => {
   const data = await req.db.Jurisdiction.findAll({
-    where: { id: { [req.db.Sequelize.Op.in]: [186, 187, 188, 189, 190, 650] } },  // 46,  650
+    where: { id: { [req.db.Sequelize.Op.in]: [186, 187, 188, 189, 190, 650] } },
     include: { association: 'state' },
   })
   return res.json(data)
@@ -40,4 +40,133 @@ exports.getState = async (req, res, next) => {
     include: { association: 'jurisdictions' },
   })
   return res.json(data)
+}
+
+///////////////////////// WIP STUFF ////////////////////////
+
+exports.getWipJurisdiction = async (req, res, next) => {
+  const { jurisdictionId } = req.params
+  const editorUserId = req.user.id
+
+  const findWipJurisdiction = async () => {
+    return await req.db.WipJurisdiction.findOne({
+      where: {
+        jurisdictionId,
+        editorUserId,
+      },
+      include: [
+        { all: true },
+        {
+          association: 'locations',
+          include: { association: 'hours' },
+        },
+      ],
+    })
+  }
+
+  const createWipJurisdiction = async () => {
+    return await req.db.sequelize.query(
+      'SELECT wip_jurisdiction_create(:jurisdictionId, :editorUserId)',
+      {
+        replacements: {
+          jurisdictionId,
+          editorUserId,
+        }
+      }
+    )
+  }
+
+  // try to find it
+  let data = await findWipJurisdiction()
+  if (data) return res.json(data)
+
+  // if it doesn't exist, create it
+  try {
+    await createWipJurisdiction()
+  } catch(e) {
+    return res.status(500).json({
+      success: false,
+      message: e.message,
+    })
+  }
+
+  data = await findWipJurisdiction()
+  return res.json(data)
+}
+
+exports.releaseWipJurisdiction = async (req, res, next) => {
+  const { wipJurisdictionId } = req.params
+  const editorUserId = req.user.id
+
+  const data = await req.db.WipJurisdiction.update({ isReleased: true }, {
+    where: {
+      id: wipJurisdictionId,
+      editorUserId,
+    },
+  })
+
+  if (data[0] === 1)
+    return res.json({ success: true })
+  else
+    return res.status(500).json({
+      success: false,
+      message: 'Release failed.',
+    })
+}
+
+exports.publishWipJurisdiction = async (req, res, next) => {
+  const { wipJurisdictionId } = req.params
+  const publisherUserId = req.user.id
+
+  try {
+    await req.db.sequelize.query(
+      'SELECT wip_jurisdiction_publish(:wipJurisdictionId, :publisherUserId)',
+      {
+        replacements: {
+          wipJurisdictionId,
+          publisherUserId,
+        }
+      }
+    )
+  } catch(e) {
+    return res.status(500).json({
+      success: false,
+      message: e.message,
+    })
+  }
+
+  return res.json({ success: true })
+}
+
+exports.updateWipJurisdiction = async (req, res, next) => {
+  const { wipJurisdictionId } = req.params
+  const userId = req.user.id
+  const updatedWip = req.body
+
+  /*
+    TODO: make the database consistent with the updatedWip
+
+    updatedWip is a nested object that looks like this:
+    {
+      ...jurisdiction details,
+      locations: [
+        ...location details,
+        hours: []
+      ],
+      importantDates: [],
+      infoTabs: [],
+      news: [],
+      notices: [],
+      phones: [],
+      urls: []
+    }
+
+    It will contain ALL of the data in the wip jurisdiction (not just the
+    changes made by the volunteer). And note that the arrays above may contain
+    new rows in addition to the existing ones :)
+  */
+
+  // this line is temporary -- we should return the actual database contents
+  // after updating, not the data that was passed in from the client.
+  return res.json(updatedWip)
 }

--- a/backend/models/wipjurisdiction.js
+++ b/backend/models/wipjurisdiction.js
@@ -13,48 +13,56 @@ module.exports = (sequelize, DataTypes) => {
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'jurisdiction',
       })
       models.WipJurisdiction.hasMany(models.WipJurisdictionImportantDate, {
         foreignKey: 'wip_jurisdiction_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'importantDates',
       })
       models.WipJurisdiction.hasMany(models.WipJurisdictionInfoTab, {
         foreignKey: 'wip_jurisdiction_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'infoTabs',
       })
       models.WipJurisdiction.hasMany(models.WipJurisdictionNews, {
         foreignKey: 'wip_jurisdiction_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'news',
       })
       models.WipJurisdiction.hasMany(models.WipJurisdictionNotice, {
         foreignKey: 'wip_jurisdiction_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'notices',
       })
       models.WipJurisdiction.hasMany(models.WipJurisdictionPhone, {
         foreignKey: 'wip_jurisdiction_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'phones',
       })
       models.WipJurisdiction.hasMany(models.WipJurisdictionUrl, {
         foreignKey: 'wip_jurisdiction_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'urls',
       })
       models.WipJurisdiction.hasMany(models.WipLocation, {
         foreignKey: 'wip_jurisdiction_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
         allownull: false,
+        as: 'locations',
       })
     }
   }

--- a/backend/models/wiplocation.js
+++ b/backend/models/wiplocation.js
@@ -17,6 +17,7 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'wip_location_id',
         onDelete: 'restrict',
         onupdate: 'cascade',
+        as: 'hours',
       })
     }
   }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -777,6 +777,23 @@
         "vary": "~1.1.2"
       }
     },
+    "express-promise-router": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-4.0.1.tgz",
+      "integrity": "sha512-kqan6QuMV7FdfN9b2uYpaKEJnxzfj57voI4IsMjgug5mBc6/hjuvoUT76Z/pvRqID2isl/NygTUe8S2MH2trMg==",
+      "requires": {
+        "is-promise": "^4.0.0",
+        "lodash.flattendeep": "^4.0.0",
+        "methods": "^1.0.0"
+      },
+      "dependencies": {
+        "is-promise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+          "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+        }
+      }
+    },
     "express-validator": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.6.1.tgz",
@@ -1377,6 +1394,11 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "cors": "^2.8.5",
     "csvtojson": "^2.0.10",
     "express": "^4.17.1",
+    "express-promise-router": "^4.0.1",
     "express-validator": "^6.6.1",
     "faker": "^5.1.0",
     "jsonwebtoken": "^8.5.1",
@@ -36,8 +37,8 @@
     "sequelize": "^6.3.5",
     "sequelize-auto": "^0.5.4",
     "sequelize-cli": "^6.2.0",
-    "winston": "^3.3.3",
-    "umzug": "^2.3.0"
+    "umzug": "^2.3.0",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "nodemon": "^2.0.4",

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,10 +1,16 @@
-const router = require('express').Router()
+const router = require('express-promise-router')()
 const control = require('@controllers/admin')
+const auth = require('@middleware/auth')
 
 router.get('/jurisdictions', control.listJurisdictions)
 router.get('/jurisdictions/me', control.listMyJurisdictions)
 router.get('/jurisdictions/:id', control.getJurisdiction)
 router.get('/states', control.listStates)
 router.get('/states/:id', control.getState)
+
+router.get('/wip/jurisdictions/:jurisdictionId',auth(['volunteer', 'admin']), control.getWipJurisdiction)
+router.put('/wip/jurisdictions/:wipJurisdictionId', auth(['volunteer', 'admin']), control.updateWipJurisdiction)
+router.put('/wip/jurisdictions/:wipJurisdictionId/release', auth(['volunteer', 'admin']), control.releaseWipJurisdiction)
+router.put('/wip/jurisdictions/:wipJurisdictionId/publish', auth(['admin']), control.publishWipJurisdiction)
 
 module.exports = router


### PR DESCRIPTION
This implements three new routes that we need for the volunteer part of the admin client:

1. **Get/create WIP** -- `GET /admin/wip/jurisdictions/:jurisdictionId` -- returns the wip jurisdiction with the given jurisdiction id. If the wip jurisdiction doesn't exist yet, it creates the wip jurisdiction (using @aNullValue's postgres function) and then returns it.

2. **Release WIP** -- `PUT /admin/wip/jurisdictions/:wipJurisdictionId/release` -- sets the isReleased flag on the wip jurisdiction to `true`

3. **Publish WIP** -- `PUT /admin/wip/jurisdictions/:wipJurisdictionId/publish` -- publishes the wip jurisdiction (using a postgres function)

It also stubs out the wip update endpoint (see the bottom of `controllers/admin.js`). @jafow can you take a crack at implementing this? The endpoint should take a nested wip jurisdiction object, perform all necessary updates and inserts, and return the entire wip jurisdiction.

