### PR TITLE
removed deletedAt field from models changed in recent migration

### DIFF
--- a/backend/models/jurisdictionimportantdate.js
+++ b/backend/models/jurisdictionimportantdate.js
@@ -85,11 +85,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/jurisdictioninfotab.js
+++ b/backend/models/jurisdictioninfotab.js
@@ -75,11 +75,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/jurisdictionnews.js
+++ b/backend/models/jurisdictionnews.js
@@ -66,11 +66,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/jurisdictionnotice.js
+++ b/backend/models/jurisdictionnotice.js
@@ -59,11 +59,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/jurisdictionphone.js
+++ b/backend/models/jurisdictionphone.js
@@ -74,11 +74,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/jurisdictionurl.js
+++ b/backend/models/jurisdictionurl.js
@@ -75,11 +75,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/location.js
+++ b/backend/models/location.js
@@ -307,11 +307,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/locationhours.js
+++ b/backend/models/locationhours.js
@@ -115,11 +115,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/stateimportantdate.js
+++ b/backend/models/stateimportantdate.js
@@ -85,11 +85,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/stateinfotab.js
+++ b/backend/models/stateinfotab.js
@@ -74,11 +74,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/statenews.js
+++ b/backend/models/statenews.js
@@ -66,11 +66,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/statenotice.js
+++ b/backend/models/statenotice.js
@@ -61,11 +61,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/statephone.js
+++ b/backend/models/statephone.js
@@ -74,11 +74,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/stateurl.js
+++ b/backend/models/stateurl.js
@@ -75,11 +75,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/userjurisdiction.js
+++ b/backend/models/userjurisdiction.js
@@ -70,11 +70,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/userstate.js
+++ b/backend/models/userstate.js
@@ -61,11 +61,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipjurisdictionimportantdate.js
+++ b/backend/models/wipjurisdictionimportantdate.js
@@ -85,11 +85,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipjurisdictioninfotab.js
+++ b/backend/models/wipjurisdictioninfotab.js
@@ -75,11 +75,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipjurisdictionnews.js
+++ b/backend/models/wipjurisdictionnews.js
@@ -66,11 +66,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipjurisdictionnotice.js
+++ b/backend/models/wipjurisdictionnotice.js
@@ -61,11 +61,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipjurisdictionphone.js
+++ b/backend/models/wipjurisdictionphone.js
@@ -74,11 +74,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipjurisdictionurl.js
+++ b/backend/models/wipjurisdictionurl.js
@@ -75,11 +75,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wiplocation.js
+++ b/backend/models/wiplocation.js
@@ -302,11 +302,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wiplocationhours.js
+++ b/backend/models/wiplocationhours.js
@@ -115,11 +115,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipstateimportantdate.js
+++ b/backend/models/wipstateimportantdate.js
@@ -85,11 +85,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipstateinfotab.js
+++ b/backend/models/wipstateinfotab.js
@@ -74,11 +74,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipstatenews.js
+++ b/backend/models/wipstatenews.js
@@ -66,11 +66,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipstatenotice.js
+++ b/backend/models/wipstatenotice.js
@@ -61,11 +61,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipstatephone.js
+++ b/backend/models/wipstatephone.js
@@ -74,11 +74,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/backend/models/wipstateurl.js
+++ b/backend/models/wipstateurl.js
@@ -75,11 +75,6 @@ module.exports = (sequelize, DataTypes) => {
         field: 'updated_at',
         allowNull: true,
       },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at',
-        allowNull: true,
-      },
     },
     {
       sequelize,


### PR DESCRIPTION
Hi @aNullValue, after the last migration I was seeing errors like `locations.deleted_at does not exist`. So I went through all the models and removed the `deletedAt` fields that you had removed in the migration. Hope this makes sense and doesn't break anything...