### PR TITLE
cicd: fix service name on ballotnav-dev

### DIFF
--- a/.github/workflows/backend-build.yaml
+++ b/.github/workflows/backend-build.yaml
@@ -93,6 +93,6 @@ jobs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: ballotnav
+        service: ballotnav-dev
         cluster: bn-dev
         wait-for-service-stability: true


### PR DESCRIPTION
fixes service name

after adding the prod environment I renamed the service for dev to better differentiate, but forgot to update this file!