### PR TITLE
fix ci deploy to use dev task and service name;

### DIFF
--- a/.github/workflows/backend-build.yaml
+++ b/.github/workflows/backend-build.yaml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Pull down currently deployed task-definition
       run: |
-        aws ecs describe-task-definition --task-definition ballotnav --query taskDefinition > task.json
+        aws ecs describe-task-definition --task-definition ballotnav-dev --query taskDefinition > task.json
 
     - name: Render task-definition template
       id: task-def


### PR DESCRIPTION
updated these infrastructure to separate dev and prod
environments. Task and service carry the -dev suffix.