### PR TITLE
Assign jurisdictions: eaj and secondary text

### DIFF
--- a/backend/controllers/admin/assignment.js
+++ b/backend/controllers/admin/assignment.js
@@ -40,6 +40,9 @@ exports.assignJurisdictions = async (req, res) => {
 exports.listJurisdictions = async (req, res, next) => {
   const data = await req.db.Jurisdiction.findAll({
     attributes: ['id', 'name'],
+    where: {
+      is_eaj: true,
+    },
     include: [
       {
         association: 'state',

--- a/client/web-admin/src/components/Dashboard/AssignJurisdictions/TransferList.js
+++ b/client/web-admin/src/components/Dashboard/AssignJurisdictions/TransferList.js
@@ -121,7 +121,7 @@ function TransferList({
                   inputProps={{ 'aria-labelledby': labelId }}
                 />
               </ListItemIcon>
-              <ListItemText id={labelId} primary={item[schema.primaryText]} />
+              <ListItemText id={labelId} primary={item[schema.primaryText]} secondary={item[schema.secondaryText]}/>
             </ListItem>
           );
         })}

--- a/client/web-admin/src/components/Dashboard/AssignJurisdictions/index.js
+++ b/client/web-admin/src/components/Dashboard/AssignJurisdictions/index.js
@@ -138,7 +138,13 @@ function AssignJurisdictions() {
         const states = {};
         jurisdictions.forEach(jdx => {
           const { id, name, state, userJurisdictions } = jdx;
-          const newJdx = { id, name, state, userJurisdictions };
+          const newJdx = {
+            id,
+            name,
+            userJurisdictions,
+            stateId: state.id,
+            stateAbbrev: state.abbreviation,
+          };
           if (!states[state.id]) {
             states[state.id] = state;
           }
@@ -282,7 +288,7 @@ function AssignJurisdictions() {
               schema={{
                 value: 'id',
                 primaryText: 'name',
-                secondaryText: 'abbreviation'
+                secondaryText: 'stateAbbrev'
               }}
             />
           </Grid>


### PR DESCRIPTION
- updated assignment listJurisdictions controller to return jurisidictions where `is_eaj: true`
- added state abbreviation secondary text to assign jurisdictions list items


![Screen Shot 2020-10-31 at 11 46 01 AM](https://user-images.githubusercontent.com/40484278/97787410-389c0180-1b6f-11eb-8756-9b7a81f0e9c6.png)
