### PR TITLE
combine prd and dev infrastructure configuration

### DIFF
--- a/.github/workflows/backend-build.yaml
+++ b/.github/workflows/backend-build.yaml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Pull down currently deployed task-definition
       run: |
-        aws ecs describe-task-definition --task-definition ballotnav-dev --query taskDefinition > task.json
+        aws ecs describe-task-definition --task-definition ballotnav --query taskDefinition > task.json
 
     - name: Render task-definition template
       id: task-def
@@ -125,7 +125,7 @@ jobs:
 
     - name: Pull down currently deployed task-definition
       run: |
-        aws ecs describe-task-definition --task-definition ballotnav --query taskDefinition > task.json
+        aws ecs describe-task-definition --task-definition prd-ballotnav --query taskDefinition > task.json
 
     - name: Render task-definition template
       id: task-def
@@ -140,5 +140,5 @@ jobs:
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: ballotnav-prd
-        cluster: bn
+        cluster: bn-dev
         wait-for-service-stability: true

--- a/backend/infrastructure/lb.tf
+++ b/backend/infrastructure/lb.tf
@@ -74,6 +74,33 @@ resource "aws_lb_listener" "https" {
   }
 }
 
+data "aws_acm_certificate" "prd_cert" {
+  domain      = "ballotnav.org"
+  types       = ["AMAZON_ISSUED"]
+  most_recent = true
+}
+# add additional cert for prd 
+resource "aws_lb_listener_certificate" "prd_cert" {
+  listener_arn    = aws_lb_listener.https.arn
+  certificate_arn = data.aws_acm_certificate.prd_cert.arn
+}
+
+resource "aws_lb_listener_rule" "host_based_weighted_routing" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 99
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.prd_target_group.arn
+  }
+
+  condition {
+    host_header {
+      values = var.prd_host_header_values
+    }
+  }
+}
+
 resource "aws_lb_target_group" "default" {
   name_prefix          = substr(local.name, 0, 6)
   port                 = var.container_port
@@ -92,4 +119,26 @@ resource "aws_lb_target_group" "default" {
     timeout             = 10
     unhealthy_threshold = 3
   }
+}
+
+# add a target group for production app running on shared cluster
+resource "aws_lb_target_group" "prd_target_group" {
+  name_prefix          = "prd-bn"
+  port                 = var.container_port
+  protocol             = "HTTP"
+  deregistration_delay = 100
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 5
+    interval            = 30
+    path                = "/status"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    timeout             = 10
+    unhealthy_threshold = 3
+  }
+  tags = merge({ Stage = "prd", Name = "prd-target-group" }, var.tags)
 }

--- a/backend/infrastructure/main.tf
+++ b/backend/infrastructure/main.tf
@@ -28,6 +28,7 @@ data "template_file" "task_definition" {
     db_hostname       = data.aws_ssm_parameter.db_hostname.arn
     token_secret      = data.aws_ssm_parameter.token_secret.arn
     postgres_password = data.aws_ssm_parameter.postgres_password.arn
+    postgres_db       = "main"
   }
 }
 
@@ -60,6 +61,7 @@ data "template_file" "task_definition_prd" {
     db_hostname       = data.aws_ssm_parameter.prd_db_hostname.arn
     token_secret      = data.aws_ssm_parameter.prd_token_secret.arn
     postgres_password = data.aws_ssm_parameter.prd_postgres_password.arn
+    postgres_db       = "prd_main"
   }
 }
 data "aws_iam_policy_document" "assume_role_policy" {

--- a/backend/infrastructure/main.tf
+++ b/backend/infrastructure/main.tf
@@ -22,6 +22,7 @@ data "template_file" "task_definition" {
     task_name        = var.task_name
     region           = var.region
     stage            = var.stage
+    project_name     = var.project_name
     # secrets injected securely from AWS SSM systems manager param store
     # https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html
     db_hostname       = data.aws_ssm_parameter.db_hostname.arn
@@ -30,6 +31,37 @@ data "template_file" "task_definition" {
   }
 }
 
+data "aws_ssm_parameter" "prd_db_hostname" {
+  name = "/prd/${var.region}/DB_HOSTNAME"
+}
+
+data "aws_ssm_parameter" "prd_token_secret" {
+  name = "/prd/${var.region}/TOKEN_SECRET"
+}
+
+data "aws_ssm_parameter" "prd_postgres_password" {
+  name = "/prd/${var.region}/POSTGRES_PASSWORD"
+}
+
+data "template_file" "task_definition_prd" {
+  template = file("templates/task-definition.json")
+  vars = {
+    container_memory = var.container_memory
+    container_cpu    = var.container_cpu
+    container_port   = var.container_port
+    container_name   = var.container_name
+    image_tag        = var.image_tag
+    cluster_name     = var.cluster_name
+    task_name        = var.task_name
+    region           = var.region
+    stage            = "prd"
+    project_name     = var.project_name
+    # secrets
+    db_hostname       = data.aws_ssm_parameter.prd_db_hostname.arn
+    token_secret      = data.aws_ssm_parameter.prd_token_secret.arn
+    postgres_password = data.aws_ssm_parameter.prd_postgres_password.arn
+  }
+}
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -95,7 +127,21 @@ resource "aws_ecs_task_definition" "task" {
   memory                   = var.container_memory
   cpu                      = var.container_cpu
   execution_role_arn       = aws_iam_role.task_exec_role.arn
+  tags                     = merge({ Name = "dev-task" }, var.tags)
 }
+
+resource "aws_ecs_task_definition" "task_prd" {
+  family = "prd-${var.task_name}"
+
+  container_definitions    = data.template_file.task_definition_prd.rendered
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  memory                   = var.container_memory
+  cpu                      = var.container_cpu
+  execution_role_arn       = aws_iam_role.task_exec_role.arn
+  tags                     = merge({ Name = "prd-task" }, var.tags)
+}
+
 
 resource "aws_security_group" "svc_sg" {
   name_prefix = "bn-loadbalancer"
@@ -124,14 +170,13 @@ resource "aws_security_group" "svc_sg" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    # security_groups = [aws_security_group.alb.id]
     cidr_blocks = ["0.0.0.0/0"]
   }
   tags = merge({ Name = "ecs-service-sg" }, var.tags)
 }
 
 resource "aws_ecs_service" "svc" {
-  name            = "${var.task_name}-${var.stage}"
+  name            = "${var.task_name}-dev"
   cluster         = aws_ecs_cluster.cluster.id
   task_definition = aws_ecs_task_definition.task.arn
   launch_type     = "FARGATE"
@@ -149,5 +194,33 @@ resource "aws_ecs_service" "svc" {
     assign_public_ip = true
   }
   depends_on = [aws_lb.alb, aws_lb_listener.https]
-  tags       = var.tags
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+  tags = merge({ Stage = "dev" }, var.tags)
+}
+
+resource "aws_ecs_service" "svc_prd" {
+  name            = "${var.task_name}-prd"
+  cluster         = aws_ecs_cluster.cluster.id
+  task_definition = aws_ecs_task_definition.task_prd.arn
+  launch_type     = "FARGATE"
+  desired_count   = var.desired_count
+
+  load_balancer {
+    container_name   = var.container_name
+    container_port   = var.container_port
+    target_group_arn = aws_lb_target_group.prd_target_group.arn
+  }
+
+  network_configuration {
+    subnets          = var.public_subnet_ids
+    security_groups  = [aws_security_group.svc_sg.id, var.db_security_group_id, var.bastion_security_group_id]
+    assign_public_ip = true
+  }
+  depends_on = [aws_lb.alb, aws_lb_listener.https, ]
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+  tags = merge({ Stage = "prd" }, var.tags)
 }

--- a/backend/infrastructure/outputs.tf
+++ b/backend/infrastructure/outputs.tf
@@ -29,3 +29,37 @@ output service_iam_role {
 output service_desired_count {
   value = aws_ecs_service.svc.desired_count
 }
+
+output prd_ecs_service_id {
+  value = aws_ecs_service.svc_prd.id
+}
+
+output prd_ecs_service_name {
+  description = "The name of the prd ECS service"
+  value       = aws_ecs_service.svc_prd.name
+}
+
+output default_target_group_name {
+  description = "target group name for the default deployment (dev)"
+  value       = aws_lb_target_group.default.name
+}
+
+output default_target_group_arn {
+  description = "target group ARN for the default deployment (dev)"
+  value       = aws_lb_target_group.default.arn
+}
+
+output prd_target_group_name {
+  description = "target group name for the prd deployment (prd)"
+  value       = aws_lb_target_group.prd_target_group.name
+}
+
+output prd_target_group_arn {
+  description = "target group ARN for the prd deployment (prd)"
+  value       = aws_lb_target_group.prd_target_group.arn
+}
+
+output prd_acm_cert_arn {
+  description = "the TLS cert used for routing requests to the prod target group"
+  value       = data.aws_acm_certificate.prd_cert.arn
+}

--- a/backend/infrastructure/templates/task-definition.json
+++ b/backend/infrastructure/templates/task-definition.json
@@ -12,7 +12,7 @@
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group" : "/${cluster_name}/${task_name}",
+        "awslogs-group" : "/${cluster_name}/${stage}/${task_name}",
         "awslogs-region": "${region}",
         "awslogs-stream-prefix": "${stage}",
         "awslogs-create-group": "true"
@@ -32,7 +32,7 @@
       { "name": "DISABLE_DB_MIGRATION_AUTO_RUN", "value": "1" },
       { "name": "TOKEN_EXPIRY", "value": "86400" },
       { "name": "POSTGRES_USER", "value": "ballotnav" },
-      { "name": "POSTGRES_DB", "value": "${stage}_main" }
+      { "name": "POSTGRES_DB", "value": "main" }
     ],
     "secrets": [
       { "name": "DB_HOSTNAME", "valueFrom": "${db_hostname}" },

--- a/backend/infrastructure/templates/task-definition.json
+++ b/backend/infrastructure/templates/task-definition.json
@@ -32,7 +32,7 @@
       { "name": "DISABLE_DB_MIGRATION_AUTO_RUN", "value": "1" },
       { "name": "TOKEN_EXPIRY", "value": "86400" },
       { "name": "POSTGRES_USER", "value": "ballotnav" },
-      { "name": "POSTGRES_DB", "value": "main" }
+      { "name": "POSTGRES_DB", "value": "${postgres_db}" }
     ],
     "secrets": [
       { "name": "DB_HOSTNAME", "valueFrom": "${db_hostname}" },

--- a/backend/infrastructure/variables.tf
+++ b/backend/infrastructure/variables.tf
@@ -53,3 +53,9 @@ variable attributes {
 variable delimiter {
   default = "-"
 }
+
+variable prd_host_header_values {
+  type        = list(string)
+  description = "List of one or more hostnames of the production API to be used for ALB host header routing"
+  default     = ["api.ballotnav.org"]
+}


### PR DESCRIPTION
this updates infrastructure configuration to allow ballotnav to run both development and production environments
on shared infrastructure as a way to save $$$$. 

The *key* piece of this to know about is using a single load balancer to route traffice via the [Host request header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host). 

This means that if a client does a request for `https://api.dev.ballotnav.org` the request will get routed to the dev app. 
And ditto for `https://api.ballotnav.org`. This kind of implicit behavior sets off some warning bells for me --- it'd be hard to debug this should something go wrong without knowing about this configuration -- so a more explicit approach would be to include a custom header that sets the app environment; we can route based on custom headers, too

e.g.

```javscript
const API_URL = "https://api.dev.ballotnav.org"
const APP_ENV = "dev"

// set a custom header and send the app env ( 'dev'|'prd')
axios.get(API_URL, { headers: { 'X-Ballotnav-Env': APP_ENV } })

```