### PR TITLE
Client/UI adjustments

### DIFF
--- a/client/web/src/components/MapPage/index.js
+++ b/client/web/src/components/MapPage/index.js
@@ -12,10 +12,13 @@ const MapPage = ({ isLoaded, jurisdictionId, saveQuery, getJurisdiction }) => {
   const location = useLocation()
   const { isMobile } = useBreakpoints()
 
-  // clear query when leaving map page
+  // clear query/data when leaving map page
   useEffect(() => {
-    return () => saveQuery(null)
-  }, [saveQuery])
+    return () => {
+      saveQuery(null)
+      getJurisdiction(null)
+    }
+  }, [saveQuery, getJurisdiction])
 
   // save query params whenever url changes
   useEffect(() => {
@@ -24,7 +27,7 @@ const MapPage = ({ isLoaded, jurisdictionId, saveQuery, getJurisdiction }) => {
 
   // load the jurisdiction whenever the id changes
   useEffect(() => {
-    if (jurisdictionId) getJurisdiction(jurisdictionId)
+    getJurisdiction(jurisdictionId)
   }, [getJurisdiction, jurisdictionId])
 
   if (!isLoaded) return null

--- a/client/web/src/components/MapPage/shared/JurisdictionSelect/index.js
+++ b/client/web/src/components/MapPage/shared/JurisdictionSelect/index.js
@@ -53,9 +53,9 @@ const JurisdictionSelect = ({
   const [selectedJurisdiction, setSelectedJurisdiction] = useState(jurisdiction)
 
   useEffect(() => {
-    if (!statesWithJurisdictions)
-      getStatesWithJurisdictions()
-    else if (statesWithJurisdictions.length === 1) // select GA automatically
+    if (!statesWithJurisdictions) getStatesWithJurisdictions()
+    else if (statesWithJurisdictions.length === 1)
+      // select GA automatically
       setSelectedState(statesWithJurisdictions[0])
   }, [statesWithJurisdictions, getStatesWithJurisdictions])
 

--- a/client/web/src/components/MapPage/shared/JurisdictionSelect/index.js
+++ b/client/web/src/components/MapPage/shared/JurisdictionSelect/index.js
@@ -61,7 +61,7 @@ const JurisdictionSelect = ({
 
   useEffect(() => {
     if (state) setSelectedState(state)
-    if (jurisdiction) setSelectedJurisdiction(jurisdiction)
+    setSelectedJurisdiction(jurisdiction)
   }, [state, jurisdiction])
 
   const handleStateChange = (state) => {

--- a/client/web/src/components/MapPage/shared/JurisdictionSelect/index.js
+++ b/client/web/src/components/MapPage/shared/JurisdictionSelect/index.js
@@ -53,7 +53,10 @@ const JurisdictionSelect = ({
   const [selectedJurisdiction, setSelectedJurisdiction] = useState(jurisdiction)
 
   useEffect(() => {
-    if (!statesWithJurisdictions) getStatesWithJurisdictions()
+    if (!statesWithJurisdictions)
+      getStatesWithJurisdictions()
+    else if (statesWithJurisdictions.length === 1) // select GA automatically
+      setSelectedState(statesWithJurisdictions[0])
   }, [statesWithJurisdictions, getStatesWithJurisdictions])
 
   useEffect(() => {

--- a/client/web/src/components/MapPage/shared/LocationDetail/index.js
+++ b/client/web/src/components/MapPage/shared/LocationDetail/index.js
@@ -5,7 +5,7 @@ import * as select from 'store/selectors'
 import VerifyBox from './VerifyBox'
 import DirectionsButton from './DirectionsButton'
 import ShareButton from './ShareButton'
-import LocationRules from './LocationRules'
+// import LocationRules from './LocationRules'
 import LocationCard from '../LocationCard'
 import Divider from '@material-ui/core/Divider'
 
@@ -36,7 +36,7 @@ const LocationDetail = ({
       </div>
       <Divider style={{ margin: '16px 0' }} />
       <VerifyBox location={location} jurisdiction={jurisdiction} />
-      <LocationRules location={location} />
+      {/*<LocationRules location={location} />*/}
     </>
   )
 }

--- a/client/web/src/components/MapPage/shared/LocationList/Summary.js
+++ b/client/web/src/components/MapPage/shared/LocationList/Summary.js
@@ -3,12 +3,13 @@ import { connect } from 'react-redux'
 import * as select from 'store/selectors'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
+import useBreakpoints from 'hooks/useBreakpoints'
 
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: 10,
   },
-  count: {
+  text: {
     fontWeight: 700,
     fontSize: 16,
   },
@@ -21,10 +22,29 @@ const useStyles = makeStyles((theme) => ({
 
 const Summary = ({ numLocations, stateAbbr, jurisdictionName }) => {
   const classes = useStyles()
+  const { isMobile } = useBreakpoints()
+  if (!jurisdictionName) {
+    return (
+      <div className={classes.root}>
+        {isMobile ? (
+          <div className={classes.text}>
+            We could not identify your jurisdiction. Please use the search
+            button above to enter your address or jurisdiction.
+          </div>
+        ) : (
+          <div className={classes.text}>
+            We could not identify your jurisdiction. Please enter your
+            address or use the dropdown above.
+          </div>
+        )}
+      </div>
+    )
+  }
+
   const word = numLocations === 1 ? 'location' : 'locations'
   return (
     <div className={classes.root}>
-      <div className={classes.count}>
+      <div className={classes.text}>
         {numLocations} known drop off {word}
         &nbsp;in{' '}
         <b>
@@ -40,14 +60,19 @@ const Summary = ({ numLocations, stateAbbr, jurisdictionName }) => {
 
 const mapStateToProps = (state) => ({
   numLocations: select.sortedLocations(state).length,
-  stateAbbr: select.state(state).abbreviation,
-  jurisdictionName: select.jurisdiction(state).name,
+  stateAbbr: select.state(state)?.abbreviation,
+  jurisdictionName: select.jurisdiction(state)?.name,
 })
 
 export default connect(mapStateToProps)(Summary)
 
 Summary.propTypes = {
   numLocations: PropTypes.number.isRequired,
-  stateAbbr: PropTypes.string.isRequired,
-  jurisdictionName: PropTypes.string.isRequired,
+  stateAbbr: PropTypes.string,
+  jurisdictionName: PropTypes.string,
+}
+
+Summary.defaultProps = {
+  stateAbbr: undefined,
+  jurisdictionName: undefined,
 }

--- a/client/web/src/components/MapPage/shared/LocationList/Summary.js
+++ b/client/web/src/components/MapPage/shared/LocationList/Summary.js
@@ -33,8 +33,8 @@ const Summary = ({ numLocations, stateAbbr, jurisdictionName }) => {
           </div>
         ) : (
           <div className={classes.text}>
-            We could not identify your jurisdiction. Please enter your
-            address or use the dropdown above.
+            We could not identify your jurisdiction. Please enter your address
+            or use the dropdown above.
           </div>
         )}
       </div>

--- a/client/web/src/components/MapPage/shared/Map/JurisdictionBoundary.js
+++ b/client/web/src/components/MapPage/shared/Map/JurisdictionBoundary.js
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { useTheme } from '@material-ui/core/styles'
+
+const JurisdictionBoundary = ({ map, jurisdiction }) => {
+  const theme = useTheme()
+
+  useEffect(() => {
+    if (!map || !jurisdiction) return
+
+    map.addSource('boundary', {
+      type: 'geojson',
+      data: jurisdiction.geojson,
+    })
+
+    map.addLayer({
+      id: 'boundary-line',
+      source: 'boundary',
+      type: 'line',
+      paint: {
+        'line-color': theme.palette.primary.main,
+        'line-width': 3,
+        'line-blur': 1,
+      },
+    })
+
+    return () => {
+      map.removeLayer('boundary-line')
+      map.removeSource('boundary')
+    }
+  }, [map, jurisdiction, theme])
+
+  return null
+}
+
+export default JurisdictionBoundary

--- a/client/web/src/components/MapPage/shared/Map/Map.js
+++ b/client/web/src/components/MapPage/shared/Map/Map.js
@@ -77,18 +77,21 @@ const Map = ({
     [selectLocation, onMapReady, fitBoundsOptions]
   )
 
-  const updateMap = useCallback((map, { center, zoom, bounds, animate }) => {
-    // setTimeout corrects an issue in mobile where map resizing was
-    // interfering with setting the center/bounds
-    setTimeout(() => {
-      if (center) {
-        if (animate) map.panTo(center)
-        else map.setCenter(center)
-      }
-      if (zoom) map.setZoom(zoom)
-      if (bounds) map.fitBounds(bounds, fitBoundsOptions)
-    })
-  }, [fitBoundsOptions])
+  const updateMap = useCallback(
+    (map, { center, zoom, bounds, animate }) => {
+      // setTimeout corrects an issue in mobile where map resizing was
+      // interfering with setting the center/bounds
+      setTimeout(() => {
+        if (center) {
+          if (animate) map.panTo(center)
+          else map.setCenter(center)
+        }
+        if (zoom) map.setZoom(zoom)
+        if (bounds) map.fitBounds(bounds, fitBoundsOptions)
+      })
+    },
+    [fitBoundsOptions]
+  )
 
   useEffect(() => {
     if (map) updateMap(map, position)

--- a/client/web/src/components/MapPage/shared/Map/Map.js
+++ b/client/web/src/components/MapPage/shared/Map/Map.js
@@ -1,10 +1,12 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react'
+import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 import mapboxgl, { styleUrl } from 'services/mapbox'
 import LocationMarkers from './LocationMarkers'
 import UserMarker from './UserMarker'
+import JurisdictionBoundary from './JurisdictionBoundary'
 import useSize from 'hooks/useSize'
+import useBreakpoints from 'hooks/useBreakpoints'
 
 const useStyles = makeStyles({
   root: {
@@ -19,17 +21,8 @@ const useStyles = makeStyles({
   },
 })
 
-const FIT_BOUNDS_OPTIONS = {
-  padding: {
-    top: 100,
-    bottom: 100,
-    left: 100,
-    right: 100,
-  },
-  animate: false,
-}
-
 const Map = ({
+  jurisdiction,
   locations,
   userLocation,
   selectedLocation,
@@ -41,6 +34,20 @@ const Map = ({
   const mapContainer = useRef(null)
   const size = useSize(mapContainer)
   const [map, setMap] = useState(null)
+  const { isMobile } = useBreakpoints()
+
+  const fitBoundsOptions = useMemo(() => {
+    const padding = isMobile ? 25 : 50
+    return {
+      padding: {
+        top: padding,
+        bottom: padding,
+        left: padding,
+        right: padding,
+      },
+      animate: false,
+    }
+  }, [isMobile])
 
   const initMap = useCallback(
     ({ center, zoom, bounds }) => {
@@ -49,7 +56,7 @@ const Map = ({
       const opts = {
         container: mapContainer.current,
         style: styleUrl,
-        fitBoundsOptions: FIT_BOUNDS_OPTIONS,
+        fitBoundsOptions,
       }
 
       if (center) opts.center = center
@@ -67,7 +74,7 @@ const Map = ({
         if (!e.originalEvent.defaultPrevented) selectLocation(null)
       })
     },
-    [selectLocation, onMapReady]
+    [selectLocation, onMapReady, fitBoundsOptions]
   )
 
   const updateMap = useCallback((map, { center, zoom, bounds, animate }) => {
@@ -79,9 +86,9 @@ const Map = ({
         else map.setCenter(center)
       }
       if (zoom) map.setZoom(zoom)
-      if (bounds) map.fitBounds(bounds, FIT_BOUNDS_OPTIONS)
+      if (bounds) map.fitBounds(bounds, fitBoundsOptions)
     })
-  }, [])
+  }, [fitBoundsOptions])
 
   useEffect(() => {
     if (map) updateMap(map, position)
@@ -103,6 +110,7 @@ const Map = ({
             selectedLocationId={selectedLocation?.id}
           />
           <UserMarker map={map} userLocation={userLocation} />
+          <JurisdictionBoundary map={map} jurisdiction={jurisdiction} />
         </>
       )}
     </div>
@@ -112,6 +120,7 @@ const Map = ({
 export default Map
 
 Map.propTypes = {
+  jurisdiction: PropTypes.shape({}),
   locations: PropTypes.arrayOf(PropTypes.shape({})),
   userLocation: PropTypes.shape({
     lng: PropTypes.number,
@@ -128,6 +137,7 @@ Map.propTypes = {
 }
 
 Map.defaultProps = {
+  jurisdiction: null,
   locations: [],
   userLocation: null,
   selectedLocationId: null,

--- a/client/web/src/components/MapPage/shared/Map/index.js
+++ b/client/web/src/components/MapPage/shared/Map/index.js
@@ -39,17 +39,17 @@ const CONTINENTAL_US = [
 const DEFAULT_ZOOM = 13
 
 const MapContainer = ({
+  jurisdiction,
   locations,
   userLocation,
   selectedLocation,
   selectLocation,
-  jurisdictionId,
   isLoading,
 }) => {
   const [position, setPosition] = useState(null)
   const [map, setMap] = useState(null)
   const delta = useDeltaObject({
-    jurisdictionId,
+    jurisdiction,
     userLocation,
     selectedLocation,
   })
@@ -66,9 +66,12 @@ const MapContainer = ({
     }
 
     // jurisdiction select
-    // NOTE: this entire block will be changed to surround
-    // the jurisdiction boundaries (when we have them)
     if (!userLocation && !selectedLocation) {
+      if (jurisdiction.geojson)
+        return setPosition({
+          bounds: bbox(jurisdiction.geojson)
+        })
+
       if (locations.length === 0)
         return setPosition({
           bounds: CONTINENTAL_US,
@@ -103,11 +106,11 @@ const MapContainer = ({
         ),
       })
     }
-  }, [locations, userLocation, selectedLocation])
+  }, [jurisdiction, locations, userLocation, selectedLocation])
 
   useEffect(() => {
     if (
-      delta.jurisdictionId ||
+      delta.jurisdiction ||
       (delta.userLocation && delta.userLocation.curr && !isLoading)
     )
       setMapPosition()
@@ -129,6 +132,7 @@ const MapContainer = ({
   if (!position) return null
   return (
     <Map
+      jurisdiction={jurisdiction}
       locations={locations}
       userLocation={userLocation}
       selectedLocation={selectedLocation}
@@ -140,10 +144,10 @@ const MapContainer = ({
 }
 
 const mapStateToProps = (state) => ({
+  jurisdiction: select.jurisdiction(state),
   locations: select.sortedLocations(state),
   userLocation: select.userLocation(state),
   selectedLocation: select.selectedLocation(state),
-  jurisdictionId: select.jurisdiction(state)?.id,
   isLoading: select.isLoading(state),
 })
 
@@ -154,6 +158,7 @@ const mapDispatchToProps = (dispatch) => ({
 export default connect(mapStateToProps, mapDispatchToProps)(MapContainer)
 
 MapContainer.propTypes = {
+  jurisdiction: PropTypes.shape({}),
   locations: PropTypes.arrayOf(PropTypes.shape({})),
   userLocation: PropTypes.shape({
     lng: PropTypes.number,
@@ -165,6 +170,7 @@ MapContainer.propTypes = {
 }
 
 MapContainer.defaultProps = {
+  jurisdiction: null,
   locations: [],
   userLocation: null,
   selectedLocationId: null,

--- a/client/web/src/components/MapPage/shared/Map/index.js
+++ b/client/web/src/components/MapPage/shared/Map/index.js
@@ -36,6 +36,11 @@ const CONTINENTAL_US = [
   [-66.885444, 49.384358],
 ]
 
+const GEORGIA = [
+  [-85.61, 30.36],
+  [-80.84, 35.0],
+]
+
 const DEFAULT_ZOOM = 13
 
 const MapContainer = ({
@@ -55,6 +60,11 @@ const MapContainer = ({
   })
 
   const setMapPosition = useCallback(() => {
+    if (!jurisdiction)
+      return setPosition({
+        bounds: GEORGIA,
+      })
+
     // search box
     if (userLocation && !selectedLocation) {
       return setPosition({

--- a/client/web/src/components/MapPage/shared/Map/index.js
+++ b/client/web/src/components/MapPage/shared/Map/index.js
@@ -79,7 +79,7 @@ const MapContainer = ({
     if (!userLocation && !selectedLocation) {
       if (jurisdiction.geojson)
         return setPosition({
-          bounds: bbox(jurisdiction.geojson)
+          bounds: bbox(jurisdiction.geojson),
         })
 
       if (locations.length === 0)

--- a/client/web/src/components/shared/SearchBar/index.js
+++ b/client/web/src/components/shared/SearchBar/index.js
@@ -21,11 +21,13 @@ function SearchBar({ center, address, onComplete, useModal, openSearchModal }) {
     async ({ lng, lat, address }) => {
       const jurisdictions = await api.getJurisdictions(lng, lat)
 
-      if (jurisdictions.length !== 1) return history.push('/error')
-
-      const { id: jid } = jurisdictions[0]
-      const query = queryString.stringify({ jid, lng, lat, address })
-      history.push(`/map?${query}`)
+      if (jurisdictions.length === 1) {
+        const { id: jid } = jurisdictions[0]
+        const query = queryString.stringify({ jid, lng, lat, address })
+        history.push(`/map?${query}`)
+      } else {
+        history.push('/map')
+      }
 
       if (onComplete) onComplete()
     },

--- a/client/web/src/components/shared/SearchBar/index.js
+++ b/client/web/src/components/shared/SearchBar/index.js
@@ -9,6 +9,11 @@ import Geocoder from './Geocoder'
 import SearchButton from './SearchButton'
 import UseMyLocation from './UseMyLocation'
 
+const GEORGIA_CENTER = {
+  lng: -83.26179,
+  lat: 32.39436,
+}
+
 function SearchBar({ center, address, onComplete, useModal, openSearchModal }) {
   const history = useHistory()
 
@@ -32,7 +37,11 @@ function SearchBar({ center, address, onComplete, useModal, openSearchModal }) {
       {useModal ? (
         <SearchButton onClick={openSearchModal} />
       ) : (
-        <Geocoder center={center} address={address} onResult={handleResult} />
+        <Geocoder
+          center={center || GEORGIA_CENTER}
+          address={address}
+          onResult={handleResult}
+        />
       )}
       <UseMyLocation onResult={handleResult} />
     </div>

--- a/client/web/src/index.js
+++ b/client/web/src/index.js
@@ -10,8 +10,6 @@ import './styles/styles.scss'
 import store from './store'
 import App from './App'
 
-console.log(theme)
-
 ReactDOM.render(
   <Provider store={store}>
     <ThemeProvider theme={theme}>

--- a/client/web/src/services/api.js
+++ b/client/web/src/services/api.js
@@ -22,6 +22,16 @@ async function getJurisdiction(jurisdictionId) {
     data: { locations, ...jurisdiction },
   } = await axios.get(url)
   const state = await getState(jurisdiction.stateId)
+
+  if (jurisdiction.geojson)
+    jurisdiction.geojson = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        geometry: JSON.parse(jurisdiction.geojson),
+      }],
+    }
+
   return {
     state,
     jurisdiction,

--- a/client/web/src/services/api.js
+++ b/client/web/src/services/api.js
@@ -26,10 +26,12 @@ async function getJurisdiction(jurisdictionId) {
   if (jurisdiction.geojson)
     jurisdiction.geojson = {
       type: 'FeatureCollection',
-      features: [{
-        type: 'Feature',
-        geometry: JSON.parse(jurisdiction.geojson),
-      }],
+      features: [
+        {
+          type: 'Feature',
+          geometry: JSON.parse(jurisdiction.geojson),
+        },
+      ],
     }
 
   return {

--- a/client/web/src/services/geolocation.js
+++ b/client/web/src/services/geolocation.js
@@ -4,7 +4,6 @@ export const getUserLocation = () => {
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
-        console.log('position:', position)
         resolve({
           lng: position.coords.longitude,
           lat: position.coords.latitude,
@@ -15,7 +14,7 @@ export const getUserLocation = () => {
       },
       {
         enableHighAccuracy: true,
-        timeout: 5000,
+        timeout: 7000,
         maximumAge: 0,
       }
     )

--- a/client/web/src/store/actions.js
+++ b/client/web/src/store/actions.js
@@ -38,6 +38,16 @@ export const saveQuery = () => {
 
 export const getJurisdiction = (jurisdictionId) => {
   return (dispatch) => {
+    if (!jurisdictionId)
+      return dispatch({
+        type: types.GET_JURISDICTION_SUCCESS,
+        data: {
+          state: null,
+          jurisdiction: null,
+          locations: null,
+        },
+      })
+
     // start timer
     mixpanel.time_event(types.GET_JURISDICTION_SUCCESS)
     dispatch({ type: types.GET_JURISDICTION_PENDING })


### PR DESCRIPTION
A couple of things to prep for the Georgia-only launch:
- removed location rules from UI
- automatically select Georgia from the state dropdown, since there aren't any other states available
- geocoder search centers on Georgia. This will reduce the likelihood of seeing "no results" in the dropdown
- if we get to the `/map` page without a jurisdictionId in the URL, there's a message instructing the user to use the search bar/dropdown, and the map centers on Georgia. This would happen in two cases: (1) the user hits "use my location" but they aren't in Georgia, or (2) the user navigates directly to `/map` (without any query params)

Also, the map now shows the boundaries of the jurisdiction.