### PR TITLE
Fix ssm perms

### DIFF
--- a/backend/infrastructure/main.tf
+++ b/backend/infrastructure/main.tf
@@ -90,7 +90,10 @@ data "aws_iam_policy_document" "logs" {
     actions = [
       "ssm:Get*"
     ]
-    resources = ["arn:aws:ssm:${var.region}:${var.account_id}:parameter/${var.stage}/*"]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/${var.stage}/*",
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/prd/*"
+    ]
   }
 }
 

--- a/backend/infrastructure/templates/task-definition.json
+++ b/backend/infrastructure/templates/task-definition.json
@@ -29,7 +29,6 @@
     },
     "environment": [
       { "name": "NODE_ENV", "value": "production" },
-      { "name": "DISABLE_DB_MIGRATION_AUTO_RUN", "value": "1" },
       { "name": "TOKEN_EXPIRY", "value": "86400" },
       { "name": "POSTGRES_USER", "value": "ballotnav" },
       { "name": "POSTGRES_DB", "value": "${postgres_db}" }


### PR DESCRIPTION
# summary

adds some fixups to the infra & backend especially relevant to prod. 

- add a required permission to SSM so the prod task can pull its secrets
- remove flag that disables db auto migration. hopefully we won't regret this later :-)